### PR TITLE
Rds: added variable, locals and changed existing module parameter

### DIFF
--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -170,3 +170,8 @@ variable "worker_security_group_id" {
 
 }
 
+variable "rds_cloudwatch_logging_enabled" {
+  description = "Enable cloudwatch logs"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
- added new boolean variable `rds_cloudwatch_logging_enabled`
- added locals named `db_engine_log_group_mapping` with default log types to export by each engine
- changed the `enabled_cloudwatch_logs_exports` parameter , so it takes values from `db_engine_log_group_mapping` by default, and has an option of overriding `db_engine_log_group_mapping` value if needed with use of `rds_enabled_cloudwatch_logs_exports` variable

issue #139