### PR TITLE
Add meta-aws-application module

### DIFF
--- a/meta-aws-application/README.md
+++ b/meta-aws-application/README.md
@@ -1,0 +1,54 @@
+# Meta AWS Application
+This module creates the deployment on a Kubernetes cluster using Helm (as an option via ArgoCD) for the abstract application with IRSA integration.
+
+## Usage:
+``` hcl
+module "aws_lb_controller" {
+  source = "github.com/provectus/sak-incubator//meta-aws-application"
+
+  chart_version = "1.2.7"
+  repository    = "https://aws.github.io/eks-charts"
+  name          = "aws-load-balancer-controller"
+  chart         = "aws-load-balancer-controller"
+
+  iam_permissions = [
+    {
+      "Effect" = "Allow",
+      "Action" = [
+        "iam:CreateServiceLinkedRole",
+        ...
+      ],
+      "Resource" = "*"
+    },
+    ...
+  ]
+
+  cluster_name = var.cluster_name
+  values = {
+    clusterName = var.cluster_name
+    vpcId       = var.vpc_id
+    region      = data.aws_region.current.name
+    defaultTags = var.tags
+  }
+  argocd = var.argocd
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:-----:|
+| argocd | A set of values for enabling deployment through ArgoCD | `map(string)` | `{}` | no |
+| chart | A Helm Chart name | `string` | n/a | yes |
+| chart\_version | Version of Helm Chart | `string` | `"0.1.0"` | no |
+| cluster\_name | A name of the Amazon EKS cluster | `string` | n/a | yes |
+| destination\_server | A destination server for ArgoCD application | `string` | `"https://kubernetes.default.svc"` | no |
+| iam\_permissions | A list of IAM permissions required for application launch | `any` | `[]` | no |
+| irsa\_annotation\_field | A filed name for specifying IRSA annotation | `string` | `"rbac.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"` | no |
+| name | A name of the application | `string` | n/a | yes |
+| namespace | A name of the existing namespace | `string` | `"default"` | no |
+| namespace\_name | A name of namespace for creating | `string` | `"application"` | no |
+| repository | A repository of Helm Chart | `string` | n/a | yes |
+| service\_account\_name | A name of the service account, in case of using custom SA name not matching with application name | `string` | `""` | no |
+| tags | A tags for attaching to new created AWS resources | `map(string)` | `{}` | no |
+| values | A values for Helm Chart | `map` | `{}` | no |

--- a/meta-aws-application/main.tf
+++ b/meta-aws-application/main.tf
@@ -1,0 +1,100 @@
+data "aws_eks_cluster" "this" {
+  name = var.cluster_name
+}
+
+resource "kubernetes_namespace" "this" {
+  count = var.namespace == "default" ? 1 - local.argocd_enabled : 0
+  metadata {
+    name = var.namespace_name
+  }
+}
+
+resource "helm_release" "app" {
+  count      = 1 - local.argocd_enabled
+  name       = local.name
+  repository = var.repository
+  chart      = var.chart
+  version    = var.chart_version
+  namespace  = local.namespace
+  timeout    = 1200
+  values     = [yamlencode(var.values)]
+  set {
+    name  = var.irsa_annotation_field
+    value = module.iam_assumable_role.iam_role_arn
+  }
+}
+
+module "iam_assumable_role" {
+  source       = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version      = "~> v4.3.0"
+  role_name    = "${var.cluster_name}_${local.name}"
+  create_role  = var.iam_permissions == [] ? false : true
+  provider_url = replace(data.aws_eks_cluster.this.identity.0.oidc.0.issuer, "https://", "")
+  role_policy_arns = [for p in aws_iam_policy.app :
+    p.arn
+  ]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.namespace}:${var.service_account_name == "" ? local.name : var.service_account_name}"]
+  tags                          = var.tags
+}
+
+resource "aws_iam_policy" "app" {
+  count = var.iam_permissions == [] ? 0 : 1
+  name  = "${var.cluster_name}_${local.name}"
+  policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = var.iam_permissions
+  })
+  tags = var.tags
+}
+
+resource "local_file" "app" {
+  count    = local.argocd_enabled
+  content  = yamlencode(local.app)
+  filename = "${var.argocd.path}/${local.name}.yaml"
+}
+
+locals {
+  name           = var.name == "" ? var.chart : var.name
+  argocd_enabled = length(var.argocd) > 0 ? 1 : 0
+  namespace      = coalescelist(kubernetes_namespace.this, [{ "metadata" = [{ "name" = var.namespace }] }])[0].metadata[0].name
+  app = {
+    "apiVersion" = "argoproj.io/v1alpha1"
+    "kind"       = "Application"
+    "metadata" = {
+      "name"      = local.name
+      "namespace" = var.argocd.namespace
+    }
+    "spec" = {
+      "destination" = {
+        "namespace" = local.namespace
+        "server"    = var.destination_server
+      }
+      "project" = var.argocd.project
+      "source" = {
+        "repoURL"        = var.repository
+        "targetRevision" = var.chart_version
+        "chart"          = var.chart
+        "helm" = {
+          "parameters" = [
+            {
+              "name"  = var.irsa_annotation_field
+              "value" = module.iam_assumable_role.iam_role_arn
+            }
+          ]
+          "values" = yamlencode(var.values)
+        }
+      }
+      "syncPolicy" = {
+        "syncOptions" = [
+          {
+            "CreateNamespace" = true
+          }
+        ]
+        "automated" = {
+          "prune"    = true
+          "selfHeal" = true
+        }
+      }
+    }
+  }
+}

--- a/meta-aws-application/main.tf
+++ b/meta-aws-application/main.tf
@@ -86,9 +86,7 @@ locals {
       }
       "syncPolicy" = {
         "syncOptions" = [
-          {
-            "CreateNamespace" = true
-          }
+          "CreateNamespace=true"
         ]
         "automated" = {
           "prune"    = true

--- a/meta-aws-application/variables.tf
+++ b/meta-aws-application/variables.tf
@@ -1,0 +1,78 @@
+variable "values" {
+  default     = {}
+  description = "A values for Helm Chart"
+}
+
+variable "namespace" {
+  type        = string
+  default     = "default"
+  description = "A name of the existing namespace"
+}
+
+variable "namespace_name" {
+  type        = string
+  default     = "application"
+  description = "A name of namespace for creating"
+}
+
+variable "cluster_name" {
+  type        = string
+  default     = null
+  description = "A name of the Amazon EKS cluster"
+}
+
+variable "chart_version" {
+  default     = "0.1.0"
+  description = "Version of Helm Chart"
+}
+
+variable "argocd" {
+  type        = map(string)
+  description = "A set of values for enabling deployment through ArgoCD"
+  default     = {}
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "A tags for attaching to new created AWS resources"
+}
+
+variable "repository" {
+  type        = string
+  description = "A repository of Helm Chart"
+}
+
+variable "chart" {
+  type        = string
+  description = "A Helm Chart name"
+}
+
+variable "name" {
+  type        = string
+  description = "A name of the application"
+}
+
+variable "iam_permissions" {
+  type        = any
+  default     = []
+  description = "A list of IAM permissions required for application launch"
+}
+
+variable "service_account_name" {
+  type        = string
+  default     = ""
+  description = "A name of the service account, in case of using custom SA name not matching with application name"
+}
+
+variable "irsa_annotation_field" {
+  type        = string
+  default     = "rbac.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+  description = "A filed name for specifying IRSA annotation"
+}
+
+variable "destination_server" {
+  type        = string
+  default     = "https://kubernetes.default.svc"
+  description = "A destination server for ArgoCD application"
+}


### PR DESCRIPTION
This module allows us to specify deployment by a common way for SAK for any application, without writing Terraform module for it.  It is could be used to create ArgoCD manifests for non-system applications or different experiments with the k8s controllers.